### PR TITLE
Adjust Linux bootstrap: Musl compat and no implicit GCC assumption

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Information provided in `system/build` info may not be correct!
 Modify existing files in the `/make` directory (if needed) and use classic `make` to build the bootstrap.
 For example:
 ```
-make -f rebol-linux-bootstrap-32bit.mk
+make -f rebol-linux-bootstrap-32bit.mk CC=clang
 ```
 If the compilation would not fail, you can use Rebol Siskin-builder script to build the normal Rebol using:
 ```

--- a/make/rebol-bsd-bootstrap-64bit.mk
+++ b/make/rebol-bsd-bootstrap-64bit.mk
@@ -4,7 +4,7 @@
 PRODUCT= rebol-bsd-bootstrap-64bit
 
 # For the build toolchain:
-CC=	   $(TOOLS)clang
+#CC=	   $(TOOLS)clang
 NM=	   $(TOOLS)nm
 STRIP= $(TOOLS)strip
 
@@ -21,7 +21,7 @@ CD= ./
 
 # Paths used by make:
 R= $(UP)
-O= $(CD)/tmp/clang-64bit/rebol-bsd-bootstrap-64bit
+O= $(CD)/tmp/cc-64bit/rebol-bsd-bootstrap-64bit
 S= $(R)/src
 
 USE_FLAGS=

--- a/make/rebol-linux-bootstrap-32bit.mk
+++ b/make/rebol-linux-bootstrap-32bit.mk
@@ -4,7 +4,7 @@
 PRODUCT= rebol-linux-bootstrap-32bit
 
 # For the build toolchain:
-CC=	   $(TOOLS)gcc
+#CC=	   $(TOOLS)gcc
 NM=	   $(TOOLS)nm
 STRIP= $(TOOLS)strip
 
@@ -21,7 +21,7 @@ CD= ./
 
 # Paths used by make:
 R= $(UP)
-O= $(CD)/tmp/gcc-32bit/rebol-linux-bootstrap-32bit
+O= $(CD)/tmp/cc-32bit/rebol-linux-bootstrap-32bit
 S= $(R)/src
 
 USE_FLAGS=

--- a/make/rebol-linux-bootstrap-64bit.mk
+++ b/make/rebol-linux-bootstrap-64bit.mk
@@ -4,7 +4,7 @@
 PRODUCT= rebol-linux-bootstrap-64bit
 
 # For the build toolchain:
-CC=	   $(TOOLS)gcc
+#CC=	   $(TOOLS)gcc
 NM=	   $(TOOLS)nm
 STRIP= $(TOOLS)strip
 
@@ -21,7 +21,7 @@ CD= ./
 
 # Paths used by make:
 R= $(UP)
-O= $(CD)/tmp/gcc-64bit/rebol-linux-bootstrap-64bit
+O= $(CD)/tmp/cc-64bit/rebol-linux-bootstrap-64bit
 S= $(R)/src
 
 USE_FLAGS=
@@ -31,6 +31,7 @@ INCLUDES= \
 
 DEFINES= \
 	-D_FILE_OFFSET_BITS=64 \
+	-D_LARGEFILE64_SOURCE \
 	-DTO_LINUX_X64 \
 	-D__LP64__ \
 	-DMBEDTLS_ASN1_PARSE_C \

--- a/make/rebol3-core-macos-x64.mk
+++ b/make/rebol3-core-macos-x64.mk
@@ -4,7 +4,7 @@
 PRODUCT= rebol3-core-macos-x64
 
 # For the build toolchain:
-CC=	   $(TOOLS)clang
+#CC=	   $(TOOLS)clang
 NM=	   $(TOOLS)nm
 STRIP= $(TOOLS)strip
 
@@ -21,7 +21,7 @@ CD= ./
 
 # Paths used by make:
 R= $(UP)
-O= $(CD)/tmp/clang-x64/rebol3-core-macos-x64
+O= $(CD)/tmp/cc-x64/rebol3-core-macos-x64
 S= $(R)/src
 
 USE_FLAGS=


### PR DESCRIPTION
- Don't assume GCC by default, prefer giving user an option of setting CC env variable with Make invocation. 
- Define -D_LARGEFILE64_SOURCE, for better compat with Musl, as per https://wiki.musl-libc.org/faq