### PR TITLE
FIX: crash when decompressing large data using gzip

### DIFF
--- a/src/core/u-compress.c
+++ b/src/core/u-compress.c
@@ -204,7 +204,7 @@ void Trap_ZStream_Error(z_stream *stream, int err, REBOOL while_compression)
 			SERIES_TAIL(output) = stream.total_out;
 			Expand_Series(output, AT_TAIL, len);
 			stream.next_out = BIN_SKIP(output, stream.total_out);
-			stream.avail_out = SERIES_REST(output) - stream.total_out;
+			stream.avail_out = SERIES_REST(output) - stream.total_out - 1;
 		}
 	}
 	//printf("total_out: %i\n", stream.total_out);

--- a/src/tests/units/crash-test.r3
+++ b/src/tests/units/crash-test.r3
@@ -251,6 +251,14 @@ if system/version > 3.17.0 [
 	--assert block? blk
 	blk: none recycle
 ]
+
+--test-- "decompress large data"
+	;@@ https://github.com/Oldes/Rebol-issues/issues/2615
+	bin: read/binary https://github.com/json-iterator/test-data/raw/master/large-file.json
+	loop 6 [
+		--assert not error? try [decompress bin 'gzip]
+	]
+
 ===end-group===
 
 ~~~end-file~~~


### PR DESCRIPTION
resolves: https://github.com/Oldes/Rebol-issues/issues/2615